### PR TITLE
Trim values

### DIFF
--- a/gh-workflow-immortality.sh
+++ b/gh-workflow-immortality.sh
@@ -58,21 +58,21 @@ if [ -n "${REPOS_USERS:-}" ]; then
         if [ -n "$REPOS_USER" ]; then
             set -- --user "$REPOS_USER" "$@"
         fi
-    done < <(printf '%s\n' "$REPOS_USERS")
+    done < <(printf '%s\n' "$REPOS_USERS" | sed 's/^\s*//;s/\s*$//;/^$/d')
 fi
 if [ -n "${REPOS_ORGS:-}" ]; then
     while IFS= read -r REPOS_ORG; do
         if [ -n "$REPOS_ORG" ]; then
             set -- --org "$REPOS_ORG" "$@"
         fi
-    done < <(printf '%s\n' "$REPOS_ORGS")
+    done < <(printf '%s\n' "$REPOS_ORGS" | sed 's/^\s*//;s/\s*$//;/^$/d')
 fi
 if [ -n "${REPOS:-}" ]; then
     while IFS= read -r REPO; do
         if [ -n "$REPO" ]; then
             set -- "$@" "$REPO"
         fi
-    done < <(printf '%s\n' "$REPOS")
+    done < <(printf '%s\n' "$REPOS" | sed 's/^\s*//;s/\s*$//;/^$/d')
 fi
 
 # helper functions


### PR DESCRIPTION
Hi, thanks for your script!

I'm inputting parameters by setting variables in the repository, but I found that when reading the parameters, line breaks are also included, causing the script to fail.

So I made some modifications to trim the leading and trailing whitespace from the read results, and tested that it works.

Since I'm not very familiar with bash either, this might not be the best solution, so feel free to modify it!

-----------

Infomations:

[My workflow](https://github.com/Tsuk1ko/keepalive-my-workflow/blob/master/.github/workflows/main.yml)

[Failed run](https://github.com/Tsuk1ko/keepalive-my-workflow/actions/runs/17187734633)

Variables:

<img width="358" height="215" alt="image" src="https://github.com/user-attachments/assets/4c4bab0d-3803-45ca-83da-6147b111aea7" />
