### PR TITLE
Add `--no-repo-names` option to suppress printing repo names

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The GitHub action will accept the following options:
 | `owner_repos`        | Loads all repositories of the authenticated GitHub user (includes both public and private repositories); either `true` or `false` | `false` | No       |
 | `collaborator_repos` | Loads all repositories of which the authenticated GitHub user is a collaborator of; either `true` or `false`                      | `false` | No       |
 | `member_repos`       | Loads all repositories of organizations of which the authenticated GitHub user is a member of; either `true` or `false`           | `false` | No       |
+| `no_repo_names`      | Prints repository IDs only instead of repository names plus IDs; either `true` or `false`                                         | `false` | No       |
 | `users`              | Loads all public repositories of the given GitHub users; expects a line separated list of GitHub user names                       | `""`    | No       |
 | `orgs`               | Loads all repositories of the given GitHub organizations; expects a line separated list of GitHub organization names              | `""`    | No       |
 | `repos`              | Loads the given repositories; expects a line separated list of GitHub repositories, e.g. `PhrozenByte/gh-workflow-immortality`    | `""`    | No       |
@@ -101,7 +102,7 @@ Repository options:
 
 Application options:
   --dry-run           don't actually enable any workflows
-  --ids               print repository IDs instead of repository names
+  --no-repo-names     don't print repository names, but repository IDs only
   --verbose           print a list of issued GitHub API requests
   --help              display this help and exit
   --version           output version information and exit
@@ -112,6 +113,7 @@ Environment variables:
   OWNER_REPOS         passing 'true' enables '--owner'
   COLLABORATOR_REPOS  passing 'true' enables '--collaborator'
   MEMBER_REPOS        passing 'true' enables '--member'
+  NO_REPO_NAMES       passing 'true' enables '--no-repo-names'
   REPOS_USERS         line separated list of GitHub users for '--user'
   REPOS_ORGS          line separated list of GitHub organizations for '--org'
   REPOS               line separated list of 'REPOSITORY' arguments
@@ -126,5 +128,5 @@ For the script to work you must set the `GITHUB_TOKEN` environment variable - ot
 ```console
 $ export GITHUB_TOKEN=my_personal_access_token
 $ ./gh-workflow-immortality.sh --owner
-GitHub repository 'PhrozenByte/gh-workflow-immortality': 0 alive and 0 dead workflows
+GitHub repository 'PhrozenByte/gh-workflow-immortality' (ID: 590682313): 0 alive and 0 dead workflows
 ```

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Repository options:
 
 Application options:
   --dry-run           don't actually enable any workflows
+  --ids               print repository IDs instead of repository names
   --verbose           print a list of issued GitHub API requests
   --help              display this help and exit
   --version           output version information and exit

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: Loads all repositories of organizations of which the authenticated GitHub user is a member of
     required: false
     default: false
+  no_repo_names:
+    description: Prints repository IDs only instead of repository names plus IDs
+    required: false
+    default: false
   users:
     description: Loads all public repositories of the given GitHub users
     required: false
@@ -45,6 +49,7 @@ runs:
         COLLABORATOR_REPOS: ${{ inputs.collaborator_repos }}
         MEMBER_REPOS: ${{ inputs.member_repos }}
         INCLUDE_FORKS: ${{ inputs.include_forks }}
+        NO_REPO_NAMES: ${{ inputs.no_repo_names }}
         REPOS_USERS: ${{ inputs.users }}
         REPOS_ORGS: ${{ inputs.orgs }}
         REPOS: ${{ inputs.repos }}

--- a/gh-workflow-immortality.sh
+++ b/gh-workflow-immortality.sh
@@ -53,6 +53,9 @@ fi
 if [ "${MEMBER_REPOS:-false}" == "true" ]; then
     set -- --member "$@"
 fi
+if [ "${NO_REPO_NAMES:-false}" == "true" ]; then
+    set -- --no-repo-names "$@"
+fi
 if [ -n "${REPOS_USERS:-}" ]; then
     while IFS= read -r REPOS_USER; do
         set -- --user "$REPOS_USER" "$@"
@@ -175,15 +178,14 @@ gh_api() {
 
 # GitHub repo loader functions
 declare -a REPOS=()
-declare -A REPO_IDS=()
+declare -a REPO_IDS=()
 
 load_repo() {
     gh_api "GET" "/repos/$1"
     [ -n "$API_RESULT" ] || return 1
 
-    local REPO_NAME="$(jq -r '.full_name' <<< "$API_RESULT")"
-    REPOS+=( "$REPO_NAME" )
-    REPO_IDS["$REPO_NAME"]="$(jq -r '.id' <<< "$API_RESULT")"
+    REPOS+=( "$(jq -r '.full_name' <<< "$API_RESULT")" )
+    REPO_IDS+=( "$(jq -r '.id' <<< "$API_RESULT")" )
 }
 
 load_repos() {
@@ -191,18 +193,11 @@ load_repos() {
     [ -n "$API_RESULT" ] || return 1
 
     local __RESULT
-    if [ -z "$FORKS" ]; then
-        __RESULT="$(jq -r '.[]|select((.fork or .archived or .disabled)|not)|[.full_name, (.id|tostring)]|@tsv' <<< "$API_RESULT")"
-    else
-        __RESULT="$(jq -r '.[]|select((.archived or .disabled)|not)|[.full_name, (.id|tostring)]|@tsv' <<< "$API_RESULT")"
-    fi
-
-    if [ -n "$__RESULT" ]; then
-        while IFS=$'\t' read -r REPO_NAME REPO_ID; do
-            REPOS+=( "$REPO_NAME" )
-            REPO_IDS["$REPO_NAME"]="$REPO_ID"
-        done <<< "$__RESULT"
-    fi
+    while IFS= read -r __RESULT; do
+        [ -n "$FORKS" ] || jq -e '.fork|not' <<< "$__RESULT" > /dev/null || continue
+        REPOS+=( "$(jq -r '.full_name' <<< "$__RESULT")" )
+        REPO_IDS+=( "$(jq -r '.id' <<< "$__RESULT")" )
+    done < <(jq -c '.[]|select((.archived or .disabled)|not)' <<< "$API_RESULT")
 }
 
 # GitHub workflow loader functions
@@ -232,7 +227,7 @@ GH_USERS=()
 GH_ORGS=()
 GH_REPOS=()
 DRY_RUN=
-IDS=
+NO_REPO_NAMES=
 VERBOSE=
 
 while [ $# -gt 0 ]; do
@@ -261,7 +256,7 @@ while [ $# -gt 0 ]; do
             echo
             echo "Application options:"
             echo "  --dry-run           don't actually enable any workflows"
-            echo "  --ids               print repository IDs instead of repository names"
+            echo "  --no-repo-names     don't print repository names, but repository IDs only"
             echo "  --verbose           print a list of issued GitHub API requests"
             echo "  --help              display this help and exit"
             echo "  --version           output version information and exit"
@@ -272,6 +267,7 @@ while [ $# -gt 0 ]; do
             echo "  OWNER_REPOS         passing 'true' enables '--owner'"
             echo "  COLLABORATOR_REPOS  passing 'true' enables '--collaborator'"
             echo "  MEMBER_REPOS        passing 'true' enables '--member'"
+            echo "  NO_REPO_NAMES       passing 'true' enables '--no-repo-names'"
             echo "  REPOS_USERS         line separated list of GitHub users for '--user'"
             echo "  REPOS_ORGS          line separated list of GitHub organizations for '--org'"
             echo "  REPOS               line separated list of 'REPOSITORY' arguments"
@@ -299,8 +295,8 @@ while [ $# -gt 0 ]; do
             shift
             ;;
 
-        "--ids")
-            IDS="y"
+        "--no-repo-names")
+            NO_REPO_NAMES="y"
             shift
             ;;
 
@@ -398,23 +394,36 @@ if [ ${#REPOS[@]} -eq 0 ]; then
 fi
 
 # remove duplicate repositories
-readarray -t REPOS < <(printf '%s\n' "${REPOS[@]}" | sort -u)
+REPOS_UNIQUE=()
+REPO_IDS_UNIQUE=()
+while IFS=$'\t' read -r REPO REPO_ID; do
+    REPOS_UNIQUE+=( "$REPO" )
+    REPO_IDS_UNIQUE+=( "$REPO_ID" )
+done < <(
+    for REPO_INDEX in "${!REPOS[@]}"; do
+        printf '%s\t%s\n' "${REPOS[$REPO_INDEX]}" "${REPO_IDS[$REPO_INDEX]}"
+    done | sort -u
+)
+REPOS=( "${REPOS_UNIQUE[@]}" )
+REPO_IDS=( "${REPO_IDS_UNIQUE[@]}" )
 
 # enable all workflows of the requested repos
 if [ -n "$DRY_RUN" ]; then
     echo "Warning: This is a dry run, no GitHub workflows will be enabled..." >&2
 fi
 
-for REPO in "${REPOS[@]}"; do
+for REPO_INDEX in "${!REPOS[@]}"; do
+    REPO="${REPOS[$REPO_INDEX]}"
+    REPO_ID="${REPO_IDS[$REPO_INDEX]}"
+
     load_workflows "$REPO" \
         || { EXIT_CODE=1; true; }
 
-    REPO_PRINT="$REPO"
-    if [ -n "$IDS" ]; then
-        REPO_PRINT="${REPO_IDS[$REPO]}"
+    if [ -n "$NO_REPO_NAMES" ]; then
+        echo "GitHub repository with ID $REPO_ID: ${#WORKFLOWS_ALIVE[@]} alive and ${#WORKFLOWS_DEAD[@]} dead workflows"
+    else
+        echo "GitHub repository '$REPO' (ID: $REPO_ID): ${#WORKFLOWS_ALIVE[@]} alive and ${#WORKFLOWS_DEAD[@]} dead workflows"
     fi
-
-    echo "GitHub repository '$REPO_PRINT': ${#WORKFLOWS_ALIVE[@]} alive and ${#WORKFLOWS_DEAD[@]} dead workflows"
 
     # enable still active workflows
     for WORKFLOW in "${WORKFLOWS_ALIVE[@]}"; do

--- a/gh-workflow-immortality.sh
+++ b/gh-workflow-immortality.sh
@@ -175,12 +175,15 @@ gh_api() {
 
 # GitHub repo loader functions
 declare -a REPOS=()
+declare -A REPO_IDS=()
 
 load_repo() {
     gh_api "GET" "/repos/$1"
     [ -n "$API_RESULT" ] || return 1
 
-    REPOS+=( "$(jq -r '.full_name' <<< "$API_RESULT")" )
+    local REPO_NAME="$(jq -r '.full_name' <<< "$API_RESULT")"
+    REPOS+=( "$REPO_NAME" )
+    REPO_IDS["$REPO_NAME"]="$(jq -r '.id' <<< "$API_RESULT")"
 }
 
 load_repos() {
@@ -189,12 +192,17 @@ load_repos() {
 
     local __RESULT
     if [ -z "$FORKS" ]; then
-        __RESULT="$(jq -r '.[]|select((.fork or .archived or .disabled)|not).full_name' <<< "$API_RESULT")"
+        __RESULT="$(jq -r '.[]|select((.fork or .archived or .disabled)|not)|[.full_name, (.id|tostring)]|@tsv' <<< "$API_RESULT")"
     else
-        __RESULT="$(jq -r '.[]|select((.archived or .disabled)|not).full_name' <<< "$API_RESULT")"
+        __RESULT="$(jq -r '.[]|select((.archived or .disabled)|not)|[.full_name, (.id|tostring)]|@tsv' <<< "$API_RESULT")"
     fi
 
-    [ -z "$__RESULT" ] || readarray -t -O "${#REPOS[@]}" REPOS <<< "$__RESULT"
+    if [ -n "$__RESULT" ]; then
+        while IFS=$'\t' read -r REPO_NAME REPO_ID; do
+            REPOS+=( "$REPO_NAME" )
+            REPO_IDS["$REPO_NAME"]="$REPO_ID"
+        done <<< "$__RESULT"
+    fi
 }
 
 # GitHub workflow loader functions
@@ -224,6 +232,7 @@ GH_USERS=()
 GH_ORGS=()
 GH_REPOS=()
 DRY_RUN=
+IDS=
 VERBOSE=
 
 while [ $# -gt 0 ]; do
@@ -252,6 +261,7 @@ while [ $# -gt 0 ]; do
             echo
             echo "Application options:"
             echo "  --dry-run           don't actually enable any workflows"
+            echo "  --ids               print repository IDs instead of repository names"
             echo "  --verbose           print a list of issued GitHub API requests"
             echo "  --help              display this help and exit"
             echo "  --version           output version information and exit"
@@ -286,6 +296,11 @@ while [ $# -gt 0 ]; do
 
         "--dry-run")
             DRY_RUN="y"
+            shift
+            ;;
+
+        "--ids")
+            IDS="y"
             shift
             ;;
 
@@ -394,7 +409,12 @@ for REPO in "${REPOS[@]}"; do
     load_workflows "$REPO" \
         || { EXIT_CODE=1; true; }
 
-    echo "GitHub repository '$REPO': ${#WORKFLOWS_ALIVE[@]} alive and ${#WORKFLOWS_DEAD[@]} dead workflows"
+    REPO_PRINT="$REPO"
+    if [ -n "$IDS" ]; then
+        REPO_PRINT="${REPO_IDS[$REPO]}"
+    fi
+
+    echo "GitHub repository '$REPO_PRINT': ${#WORKFLOWS_ALIVE[@]} alive and ${#WORKFLOWS_DEAD[@]} dead workflows"
 
     # enable still active workflows
     for WORKFLOW in "${WORKFLOWS_ALIVE[@]}"; do


### PR DESCRIPTION
Resolves #4. Example:

```console
$ ./gh-workflow-immortality.sh --no-repo-names
Loading GitHub repositories of authenticated user...
GitHub repository with ID 659434994: 0 alive and 0 dead workflows
GitHub repository with ID 4630102: 0 alive and 0 dead workflows
GitHub repository with ID 1175674552: 1 alive and 0 dead workflows
- Enabling still active workflow: main.yml
GitHub repository with ID 1133613563: 1 alive and 0 dead workflows
- Enabling still active workflow: main.yml
GitHub repository with ID 1143373370: 1 alive and 0 dead workflows
- Enabling still active workflow: main.yml
GitHub repository with ID 1061426457: 1 alive and 0 dead workflows
- Enabling still active workflow: tests.yml
GitHub repository with ID 1056919900: 1 alive and 0 dead workflows
- Enabling still active workflow: main.yml
GitHub repository with ID 866827919: 1 alive and 0 dead workflows
- Enabling still active workflow: main.yml
GitHub repository with ID 1170340847: 0 alive and 0 dead workflows
GitHub repository with ID 1177956749: 1 alive and 0 dead workflows
- Enabling still active workflow: main.yml
GitHub repository with ID 764791732: 0 alive and 0 dead workflows
```